### PR TITLE
feat: unified full screen attachment viewer

### DIFF
--- a/app/src/main/java/org/example/memosm/ui/component/item/AttachmentCard.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/AttachmentCard.kt
@@ -93,6 +93,8 @@ fun AttachmentCard(
     showSize: Boolean = true,
     showFilename: Boolean = true,
     compactMode: AttachmentCompactMode = AttachmentCompactMode.Area,
+    isFullScreen: Boolean = false,
+    onClick: (() -> Unit)? = null,
     onRatioAvailable: (Float, Boolean) -> Unit = { _, _ -> }
 ) {
     val context = LocalContext.current
@@ -303,7 +305,9 @@ fun AttachmentCard(
                                 intrinsicRatio = it
                                 isIntrinsicExact = true
                             },
-                            onClick = { showFullScreenImage = true })
+                            onClick = if (isFullScreen) null else { onClick ?: { showFullScreenImage = true } },
+                            isFullScreen = isFullScreen
+                        )
                     } else if (isVideo) {
                         val videoUrl =
                             if (uri != Uri.EMPTY) uri.toString() else AttachmentManager.getAttachmentUrl(
@@ -314,6 +318,8 @@ fun AttachmentCard(
                                 url = videoUrl,
                                 token = token,
                                 modifier = Modifier.fillMaxSize(),
+                                isFullScreen = isFullScreen,
+                                onClick = if (isFullScreen) null else onClick,
                                 onRatioAvailable = {
                                     intrinsicRatio = it
                                     isIntrinsicExact = true
@@ -350,7 +356,9 @@ fun AttachmentCard(
                                 filename = filename,
                                 isRound = true,
                                 modifier = Modifier.fillMaxSize(),
-                                onClick = { showFullScreenImage = true })
+                                onClick = if (isFullScreen) null else { onClick ?: { showFullScreenImage = true } },
+                                isFullScreen = isFullScreen
+                            )
                         } else {
                             FileThumbnail(
                                 displayType = displayType,
@@ -360,7 +368,7 @@ fun AttachmentCard(
                                     isCompact -> FileThumbnailMode.COMPACT
                                     else -> FileThumbnailMode.NORMAL
                                 },
-                                onClick = { showInfoDialog = true },
+                                onClick = if (isFullScreen) { {} } else { onClick ?: { showInfoDialog = true } },
                                 modifier = Modifier.fillMaxSize()
                             )
                         }
@@ -596,7 +604,7 @@ fun AttachmentCard(
             }
         }
 
-        if (model != null) {
+        if (model != null && !isFullScreen) {
             FullScreenImageViewer(
                 model = model,
                 filename = filename,

--- a/app/src/main/java/org/example/memosm/ui/component/item/AttachmentCard.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/AttachmentCard.kt
@@ -95,6 +95,7 @@ fun AttachmentCard(
     compactMode: AttachmentCompactMode = AttachmentCompactMode.Area,
     isFullScreen: Boolean = false,
     onClick: (() -> Unit)? = null,
+    onDismiss: (() -> Unit)? = null,
     onRatioAvailable: (Float, Boolean) -> Unit = { _, _ -> }
 ) {
     val context = LocalContext.current
@@ -306,7 +307,8 @@ fun AttachmentCard(
                                 isIntrinsicExact = true
                             },
                             onClick = if (isFullScreen) null else { onClick ?: { showFullScreenImage = true } },
-                            isFullScreen = isFullScreen
+                            isFullScreen = isFullScreen,
+                            onDismiss = onDismiss
                         )
                     } else if (isVideo) {
                         val videoUrl =
@@ -320,6 +322,7 @@ fun AttachmentCard(
                                 modifier = Modifier.fillMaxSize(),
                                 isFullScreen = isFullScreen,
                                 onClick = if (isFullScreen) null else onClick,
+                                onDismiss = onDismiss,
                                 onRatioAvailable = {
                                     intrinsicRatio = it
                                     isIntrinsicExact = true
@@ -331,6 +334,7 @@ fun AttachmentCard(
                             filename = filename,
                             token = token,
                             mode = when {
+                                    isFullScreen -> AudioPlayerMode.NORMAL
                                 isWide -> AudioPlayerMode.WIDE
                                 isCompact -> AudioPlayerMode.COMPACT
                                 else -> AudioPlayerMode.NORMAL
@@ -357,13 +361,15 @@ fun AttachmentCard(
                                 isRound = true,
                                 modifier = Modifier.fillMaxSize(),
                                 onClick = if (isFullScreen) null else { onClick ?: { showFullScreenImage = true } },
-                                isFullScreen = isFullScreen
+                                isFullScreen = isFullScreen,
+                                onDismiss = onDismiss
                             )
                         } else {
                             FileThumbnail(
                                 displayType = displayType,
                                 filename = filename,
                                 mode = when {
+                                    isFullScreen -> FileThumbnailMode.NORMAL
                                     isWide -> FileThumbnailMode.WIDE
                                     isCompact -> FileThumbnailMode.COMPACT
                                     else -> FileThumbnailMode.NORMAL

--- a/app/src/main/java/org/example/memosm/ui/component/item/MemoItem.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/MemoItem.kt
@@ -91,6 +91,7 @@ import org.example.memosm.model.Reaction
 import org.example.memosm.model.User
 import org.example.memosm.ui.VisibilityIcon
 import org.example.memosm.ui.component.item.markdown.NativeComposeMarkdown
+import org.example.memosm.ui.component.item.media.FullScreenAttachmentViewer
 import org.example.memosm.ui.component.resolveResourceUrl
 
 
@@ -122,6 +123,8 @@ fun MemoItem(
     var showMenu by remember { mutableStateOf(false) }
     var showReactionPicker by remember { mutableStateOf(false) }
     var showRawTextDialog by remember { mutableStateOf(false) }
+    var showFullScreenViewer by remember { mutableStateOf(false) }
+    var fullScreenInitialIndex by remember { mutableStateOf(0) }
     val context = LocalContext.current
 
     val unknownTime = stringResource(R.string.memo_unknown_time)
@@ -533,7 +536,7 @@ fun MemoItem(
                                 .fillMaxWidth()
                                 .padding(end = 8.dp)
                         ) {
-                            attachments.forEach { attachment ->
+                            attachments.forEachIndexed { index, attachment ->
                                 var aspectRatio by remember(
                                     attachment.name ?: attachment.filename
                                 ) {
@@ -547,6 +550,10 @@ fun MemoItem(
                                         .fillMaxWidth()
                                         .aspectRatio(aspectRatio),
                                     compactMode = AttachmentCompactMode.Never,
+                                    onClick = {
+                                        fullScreenInitialIndex = index
+                                        showFullScreenViewer = true
+                                    },
                                     onRatioAvailable = { ratio, _ -> aspectRatio = ratio })
                             }
                         }
@@ -591,7 +598,11 @@ fun MemoItem(
                                     hostUrl = hostUrl,
                                     modifier = Modifier.size(width = 240.dp, height = 160.dp),
                                     showInfo = false,
-                                    compactMode = AttachmentCompactMode.Area
+                                    compactMode = AttachmentCompactMode.Area,
+                                    onClick = {
+                                        fullScreenInitialIndex = index
+                                        showFullScreenViewer = true
+                                    }
                                 )
                             }
                         }
@@ -685,6 +696,17 @@ fun MemoItem(
                     Text(stringResource(R.string.common_close))
                 }
             })
+    }
+
+    if (showFullScreenViewer) {
+        val attachments = remember(memo.attachments) { memo.attachments ?: emptyList() }
+        FullScreenAttachmentViewer(
+            attachments = attachments,
+            initialIndex = fullScreenInitialIndex,
+            token = token,
+            hostUrl = hostUrl,
+            onDismiss = { showFullScreenViewer = false }
+        )
     }
 }
 

--- a/app/src/main/java/org/example/memosm/ui/component/item/markdown/NativeMarkdownAttachmentImage.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/markdown/NativeMarkdownAttachmentImage.kt
@@ -63,6 +63,7 @@ fun NativeMarkdownAttachmentImage(content: String, node: ASTNode) {
         showSize = false,
         showFilename = false,
         compactMode = AttachmentCompactMode.Never,
+        onClick = null, // Defaults to showFullScreenImage inside AttachmentCard which is acceptable for isolated markdown images.
         onRatioAvailable = { ratio, _ ->
             if (ratio > 0) {
                 aspectRatio = ratio

--- a/app/src/main/java/org/example/memosm/ui/component/item/media/FullScreenAttachmentViewer.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/media/FullScreenAttachmentViewer.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.activity.compose.PredictiveBackHandler
+import kotlinx.coroutines.flow.catch
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -73,18 +75,40 @@ fun FullScreenAttachmentViewer(
 
         // Vertical drag to dismiss
         val dismissOffset = remember { Animatable(0f) }
+
+        // Predictive back gesture state
+        val backProgress = remember { Animatable(0f) }
+        val backEdgeProgress = remember { Animatable(0f) }
+
         val dismissDragProgress = (abs(dismissOffset.value) / 300f).coerceIn(0f, 1f)
-        val backgroundAlpha = (1f - dismissDragProgress).coerceIn(0f, 1f)
-        val dismissScale = (1f - (abs(dismissOffset.value) / 1000f)).coerceIn(0.6f, 1f)
+
+        // Combine background alpha and scale from both gestures
+        val combinedAlpha = ((1f - dismissDragProgress) * (1f - backProgress.value * 0.5f)).coerceIn(0f, 1f)
+        val combinedScale = ((1f - (abs(dismissOffset.value) / 1000f)) * (1f - backProgress.value * 0.1f)).coerceIn(0.6f, 1f)
 
         LaunchedEffect(pagerState.currentPage) {
             onPageChanged?.invoke(pagerState.currentPage)
         }
 
+        PredictiveBackHandler { progress ->
+            try {
+                progress.collect { backEvent ->
+                    backProgress.snapTo(backEvent.progress)
+                    // Edge 0 is left, 1 is right
+                    backEdgeProgress.snapTo(if (backEvent.swipeEdge == 0) 1f else -1f)
+                }
+                onDismiss()
+            } catch (e: Exception) {
+                // Cancelled
+                backProgress.animateTo(0f)
+                backEdgeProgress.animateTo(0f)
+            }
+        }
+
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color.Black.copy(alpha = backgroundAlpha))
+                .background(Color.Black.copy(alpha = combinedAlpha))
         ) {
             Box(
                 modifier = Modifier
@@ -109,9 +133,11 @@ fun FullScreenAttachmentViewer(
                         )
                     }
                     .graphicsLayer {
-                        scaleX = dismissScale
-                        scaleY = dismissScale
+                        scaleX = combinedScale
+                        scaleY = combinedScale
                         translationY = dismissOffset.value
+                        // Shift horizontally slightly based on predictive back edge
+                        translationX = backProgress.value * 100f * backEdgeProgress.value
                     }
             ) {
                 HorizontalPager(
@@ -145,7 +171,7 @@ fun FullScreenAttachmentViewer(
                     .align(Alignment.TopEnd)
                     .padding(16.dp)
                     .statusBarsPadding()
-                    .graphicsLayer { alpha = backgroundAlpha }) {
+                    .graphicsLayer { alpha = combinedAlpha }) {
                 IconButton(
                     onClick = onDismiss,
                     modifier = Modifier.background(Color.Black.copy(alpha = 0.4f), CircleShape)

--- a/app/src/main/java/org/example/memosm/ui/component/item/media/FullScreenAttachmentViewer.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/media/FullScreenAttachmentViewer.kt
@@ -1,0 +1,161 @@
+package org.example.memosm.ui.component.item.media
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import kotlinx.coroutines.launch
+import org.example.memosm.R
+import org.example.memosm.model.Attachment
+import org.example.memosm.ui.component.item.AttachmentCard
+import org.example.memosm.ui.component.item.AttachmentCompactMode
+import kotlin.math.abs
+
+@Composable
+fun FullScreenAttachmentViewer(
+    attachments: List<Attachment>,
+    initialIndex: Int,
+    token: String?,
+    hostUrl: String,
+    onDismiss: () -> Unit,
+    onPageChanged: ((Int) -> Unit)? = null
+) {
+    if (attachments.isEmpty() || initialIndex < 0 || initialIndex >= attachments.size) {
+        return
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss, properties = DialogProperties(
+            usePlatformDefaultWidth = false, decorFitsSystemWindows = false
+        )
+    ) {
+        val window = (LocalView.current.parent as? DialogWindowProvider)?.window
+        if (window != null) {
+            SideEffect {
+                val controller = WindowCompat.getInsetsController(window, window.decorView)
+                controller.hide(WindowInsetsCompat.Type.systemBars())
+                controller.systemBarsBehavior =
+                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
+        }
+
+        val pagerState = rememberPagerState(initialPage = initialIndex, pageCount = { attachments.size })
+        val coroutineScope = rememberCoroutineScope()
+
+        // Vertical drag to dismiss
+        val dismissOffset = remember { Animatable(0f) }
+        val dismissDragProgress = (abs(dismissOffset.value) / 300f).coerceIn(0f, 1f)
+        val backgroundAlpha = (1f - dismissDragProgress).coerceIn(0f, 1f)
+        val dismissScale = (1f - (abs(dismissOffset.value) / 1000f)).coerceIn(0.6f, 1f)
+
+        LaunchedEffect(pagerState.currentPage) {
+            onPageChanged?.invoke(pagerState.currentPage)
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = backgroundAlpha))
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        detectVerticalDragGestures(
+                            onDragEnd = {
+                                coroutineScope.launch {
+                                    if (abs(dismissOffset.value) > 200f) {
+                                        onDismiss()
+                                    } else {
+                                        dismissOffset.animateTo(0f)
+                                    }
+                                }
+                            },
+                            onVerticalDrag = { change, dragAmount ->
+                                change.consume()
+                                coroutineScope.launch {
+                                    dismissOffset.snapTo(dismissOffset.value + dragAmount)
+                                }
+                            }
+                        )
+                    }
+                    .graphicsLayer {
+                        scaleX = dismissScale
+                        scaleY = dismissScale
+                        translationY = dismissOffset.value
+                    }
+            ) {
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier.fillMaxSize()
+                ) { page ->
+                    val attachment = attachments[page]
+
+                    // The AttachmentCard should handle its own zooming internally if isFullScreen=true.
+                    // The swipe up/down gesture is captured by the parent box above,
+                    // unless the child consumes it (which it shouldn't if we just want swipe to dismiss).
+                    AttachmentCard(
+                        attachment = attachment,
+                        token = token,
+                        hostUrl = hostUrl,
+                        modifier = Modifier.fillMaxSize(),
+                        showInfo = false,
+                        showActions = false,
+                        showSize = false,
+                        showFilename = false,
+                        compactMode = AttachmentCompactMode.Never,
+                        isFullScreen = true
+                    )
+                }
+            }
+
+            // Close Button
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(16.dp)
+                    .statusBarsPadding()
+                    .graphicsLayer { alpha = backgroundAlpha }) {
+                IconButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.background(Color.Black.copy(alpha = 0.4f), CircleShape)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = stringResource(R.string.common_close),
+                        tint = Color.White
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/example/memosm/ui/component/item/media/FullScreenAttachmentViewer.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/media/FullScreenAttachmentViewer.kt
@@ -133,7 +133,8 @@ fun FullScreenAttachmentViewer(
                         showSize = false,
                         showFilename = false,
                         compactMode = AttachmentCompactMode.Never,
-                        isFullScreen = true
+                        isFullScreen = true,
+                        onDismiss = onDismiss
                     )
                 }
             }

--- a/app/src/main/java/org/example/memosm/ui/component/item/media/MemoImage.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/media/MemoImage.kt
@@ -28,6 +28,9 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.graphicsLayer
 import coil3.compose.AsyncImage
 import coil3.network.NetworkHeaders
 import coil3.network.httpHeaders
@@ -50,7 +53,8 @@ fun MemoImage(
     isRound: Boolean = false,
     placeholderIcon: ImageVector? = null,
     onRatioAvailable: (Float) -> Unit = {},
-    onClick: (() -> Unit)? = null
+    onClick: (() -> Unit)? = null,
+    isFullScreen: Boolean = false
 ) {
     val context = LocalContext.current
     val modelState = produceState<Any?>(initialValue = null, uri, attachment, hostUrl) {
@@ -114,14 +118,32 @@ fun MemoImage(
         modifier = modifier, contentAlignment = Alignment.Center
     ) {
         if (model != null) {
+            val imgModifier = Modifier
+                .fillMaxSize()
+                .then(if (isRound) Modifier.clip(CircleShape) else Modifier)
+                .then(if (onClick != null && !isFullScreen) Modifier.clickable { onClick() } else Modifier)
+
             AsyncImage(
                 model = imageRequest,
                 contentDescription = filename,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .then(if (isRound) Modifier.clip(CircleShape) else Modifier)
-                    .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier),
-                contentScale = ContentScale.Crop,
+                modifier = if (isFullScreen) {
+                    var scale by remember { androidx.compose.runtime.mutableFloatStateOf(1f) }
+                    var offset by remember { mutableStateOf(androidx.compose.ui.geometry.Offset.Zero) }
+                    imgModifier
+                        .pointerInput(Unit) {
+                            detectTransformGestures { _, pan, zoom, _ ->
+                                scale = (scale * zoom).coerceIn(1f, 5f)
+                                offset = if (scale > 1f) offset + pan else androidx.compose.ui.geometry.Offset.Zero
+                            }
+                        }
+                        .graphicsLayer(
+                            scaleX = scale,
+                            scaleY = scale,
+                            translationX = offset.x,
+                            translationY = offset.y
+                        )
+                } else imgModifier,
+                contentScale = if (isFullScreen) ContentScale.Fit else ContentScale.Crop,
                 onLoading = { isLoading = true; isError = false },
                 onSuccess = { state ->
                     isLoading = false

--- a/app/src/main/java/org/example/memosm/ui/component/item/media/MemoImage.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/media/MemoImage.kt
@@ -54,7 +54,8 @@ fun MemoImage(
     placeholderIcon: ImageVector? = null,
     onRatioAvailable: (Float) -> Unit = {},
     onClick: (() -> Unit)? = null,
-    isFullScreen: Boolean = false
+    isFullScreen: Boolean = false,
+    onDismiss: (() -> Unit)? = null
 ) {
     val context = LocalContext.current
     val modelState = produceState<Any?>(initialValue = null, uri, attachment, hostUrl) {
@@ -126,23 +127,7 @@ fun MemoImage(
             AsyncImage(
                 model = imageRequest,
                 contentDescription = filename,
-                modifier = if (isFullScreen) {
-                    var scale by remember { androidx.compose.runtime.mutableFloatStateOf(1f) }
-                    var offset by remember { mutableStateOf(androidx.compose.ui.geometry.Offset.Zero) }
-                    imgModifier
-                        .pointerInput(Unit) {
-                            detectTransformGestures { _, pan, zoom, _ ->
-                                scale = (scale * zoom).coerceIn(1f, 5f)
-                                offset = if (scale > 1f) offset + pan else androidx.compose.ui.geometry.Offset.Zero
-                            }
-                        }
-                        .graphicsLayer(
-                            scaleX = scale,
-                            scaleY = scale,
-                            translationX = offset.x,
-                            translationY = offset.y
-                        )
-                } else imgModifier,
+                modifier = imgModifier.zoomable(isFullScreen, onDismiss),
                 contentScale = if (isFullScreen) ContentScale.Fit else ContentScale.Crop,
                 onLoading = { isLoading = true; isError = false },
                 onSuccess = { state ->

--- a/app/src/main/java/org/example/memosm/ui/component/item/media/VideoPlayer.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/media/VideoPlayer.kt
@@ -24,6 +24,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -48,6 +51,8 @@ fun VideoPlayer(
     url: String,
     token: String?,
     modifier: Modifier = Modifier,
+    isFullScreen: Boolean = false,
+    onClick: (() -> Unit)? = null,
     onRatioAvailable: (Float) -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -105,6 +110,9 @@ fun VideoPlayer(
         modifier = modifier.background(MaterialTheme.colorScheme.surfaceVariant),
         contentAlignment = Alignment.Center
     ) {
+        var scale by remember { androidx.compose.runtime.mutableFloatStateOf(1f) }
+        var offset by remember { mutableStateOf(androidx.compose.ui.geometry.Offset.Zero) }
+
         AndroidView(
             factory = { ctx ->
                 PlayerView(ctx).apply {
@@ -113,16 +121,43 @@ fun VideoPlayer(
                     resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
                     setBackgroundColor(android.graphics.Color.TRANSPARENT)
                     setShutterBackgroundColor(android.graphics.Color.TRANSPARENT)
-                    setFullscreenButtonClickListener { isFullscreen = true }
+                    if (isFullScreen) {
+                        setFullscreenButtonClickListener { /* disabled */ }
+                        controllerShowTimeoutMs = 3000
+                    } else {
+                        setFullscreenButtonClickListener { isFullscreen = true }
+                    }
                     layoutParams = ViewGroup.LayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
                     )
+
+                    if (!isFullScreen && onClick != null) {
+                        setOnClickListener { onClick() }
+                    }
                 }
             }, update = { view ->
                 view.player = if (isFullscreen) null else exoPlayer
-            }, modifier = Modifier
-                .fillMaxSize()
-                .alpha(if (isReady) 1f else 0f)
+            }, modifier = if (isFullScreen) {
+                Modifier
+                    .fillMaxSize()
+                    .alpha(if (isReady) 1f else 0f)
+                    .pointerInput(Unit) {
+                        detectTransformGestures { _, pan, zoom, _ ->
+                            scale = (scale * zoom).coerceIn(1f, 5f)
+                            offset = if (scale > 1f) offset + pan else androidx.compose.ui.geometry.Offset.Zero
+                        }
+                    }
+                    .graphicsLayer(
+                        scaleX = scale,
+                        scaleY = scale,
+                        translationX = offset.x,
+                        translationY = offset.y
+                    )
+            } else {
+                Modifier
+                    .fillMaxSize()
+                    .alpha(if (isReady) 1f else 0f)
+            }
         )
         if (!isReady) CircularProgressIndicator(modifier = Modifier.size(32.dp))
     }

--- a/app/src/main/java/org/example/memosm/ui/component/item/media/VideoPlayer.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/media/VideoPlayer.kt
@@ -53,6 +53,7 @@ fun VideoPlayer(
     modifier: Modifier = Modifier,
     isFullScreen: Boolean = false,
     onClick: (() -> Unit)? = null,
+    onDismiss: (() -> Unit)? = null,
     onRatioAvailable: (Float) -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -110,9 +111,6 @@ fun VideoPlayer(
         modifier = modifier.background(MaterialTheme.colorScheme.surfaceVariant),
         contentAlignment = Alignment.Center
     ) {
-        var scale by remember { androidx.compose.runtime.mutableFloatStateOf(1f) }
-        var offset by remember { mutableStateOf(androidx.compose.ui.geometry.Offset.Zero) }
-
         AndroidView(
             factory = { ctx ->
                 PlayerView(ctx).apply {
@@ -137,27 +135,10 @@ fun VideoPlayer(
                 }
             }, update = { view ->
                 view.player = if (isFullscreen) null else exoPlayer
-            }, modifier = if (isFullScreen) {
-                Modifier
-                    .fillMaxSize()
-                    .alpha(if (isReady) 1f else 0f)
-                    .pointerInput(Unit) {
-                        detectTransformGestures { _, pan, zoom, _ ->
-                            scale = (scale * zoom).coerceIn(1f, 5f)
-                            offset = if (scale > 1f) offset + pan else androidx.compose.ui.geometry.Offset.Zero
-                        }
-                    }
-                    .graphicsLayer(
-                        scaleX = scale,
-                        scaleY = scale,
-                        translationX = offset.x,
-                        translationY = offset.y
-                    )
-            } else {
-                Modifier
-                    .fillMaxSize()
-                    .alpha(if (isReady) 1f else 0f)
-            }
+            }, modifier = Modifier
+                .fillMaxSize()
+                .alpha(if (isReady) 1f else 0f)
+                .zoomable(isFullScreen, onDismiss)
         )
         if (!isReady) CircularProgressIndicator(modifier = Modifier.size(32.dp))
     }

--- a/app/src/main/java/org/example/memosm/ui/component/item/media/ZoomableModifier.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/media/ZoomableModifier.kt
@@ -1,19 +1,19 @@
 package org.example.memosm.ui.component.item.media
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.VectorConverter
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.calculatePan
 import androidx.compose.foundation.gestures.calculateZoom
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import kotlinx.coroutines.launch
 
 fun Modifier.zoomable(
     enabled: Boolean,
@@ -21,8 +21,9 @@ fun Modifier.zoomable(
 ): Modifier = composed {
     if (!enabled) return@composed this
 
-    var scale by remember { mutableFloatStateOf(1f) }
-    var offset by remember { mutableStateOf(Offset.Zero) }
+    val scale = remember { Animatable(1f) }
+    val offset = remember { Animatable(Offset.Zero, Offset.VectorConverter) }
+    val coroutineScope = rememberCoroutineScope()
 
     this
         .pointerInput(Unit) {
@@ -33,34 +34,42 @@ fun Modifier.zoomable(
                     val zoom = event.calculateZoom()
                     val pan = event.calculatePan()
 
-                    scale = (scale * zoom).coerceIn(0.5f, 5f)
+                    coroutineScope.launch {
+                        val newScale = (scale.value * zoom).coerceIn(0.5f, 5f)
+                        scale.snapTo(newScale)
 
-                    if (scale < 0.8f) {
-                        onDismiss?.invoke()
-                        scale = 1f
-                        offset = Offset.Zero
-                    } else if (scale > 1f) {
-                        offset += pan
-                        // Consume the gesture so parent pagers/scrolls don't intercept it
+                        if (newScale > 1f) {
+                            offset.snapTo(offset.value + pan)
+                        } else {
+                            offset.snapTo(Offset.Zero)
+                        }
+                    }
+
+                    if (scale.value > 1f) {
                         event.changes.forEach { it.consume() }
-                    } else {
-                        offset = Offset.Zero
-                        // Do not consume the gesture if scale <= 1f, allowing HorizontalPager to swipe
                     }
 
                 } while (event.changes.any { it.pressed })
 
-                // Reset scale and offset on release if scale is less than 1f
-                if (scale < 1f) {
-                    scale = 1f
-                    offset = Offset.Zero
+                // Gesture ended (all pointers up)
+                coroutineScope.launch {
+                    if (scale.value < 0.8f) {
+                        onDismiss?.invoke()
+                        // Don't snap immediately so it looks smoother as it closes
+                        scale.animateTo(1f)
+                        offset.animateTo(Offset.Zero)
+                    } else if (scale.value < 1f) {
+                        // Bounced back if they didn't pinch enough
+                        scale.animateTo(1f)
+                        offset.animateTo(Offset.Zero)
+                    }
                 }
             }
         }
         .graphicsLayer(
-            scaleX = scale,
-            scaleY = scale,
-            translationX = offset.x,
-            translationY = offset.y
+            scaleX = scale.value,
+            scaleY = scale.value,
+            translationX = offset.value.x,
+            translationY = offset.value.y
         )
 }

--- a/app/src/main/java/org/example/memosm/ui/component/item/media/ZoomableModifier.kt
+++ b/app/src/main/java/org/example/memosm/ui/component/item/media/ZoomableModifier.kt
@@ -1,0 +1,66 @@
+package org.example.memosm.ui.component.item.media
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+
+fun Modifier.zoomable(
+    enabled: Boolean,
+    onDismiss: (() -> Unit)? = null
+): Modifier = composed {
+    if (!enabled) return@composed this
+
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+
+    this
+        .pointerInput(Unit) {
+            awaitEachGesture {
+                awaitFirstDown()
+                do {
+                    val event = awaitPointerEvent()
+                    val zoom = event.calculateZoom()
+                    val pan = event.calculatePan()
+
+                    scale = (scale * zoom).coerceIn(0.5f, 5f)
+
+                    if (scale < 0.8f) {
+                        onDismiss?.invoke()
+                        scale = 1f
+                        offset = Offset.Zero
+                    } else if (scale > 1f) {
+                        offset += pan
+                        // Consume the gesture so parent pagers/scrolls don't intercept it
+                        event.changes.forEach { it.consume() }
+                    } else {
+                        offset = Offset.Zero
+                        // Do not consume the gesture if scale <= 1f, allowing HorizontalPager to swipe
+                    }
+
+                } while (event.changes.any { it.pressed })
+
+                // Reset scale and offset on release if scale is less than 1f
+                if (scale < 1f) {
+                    scale = 1f
+                    offset = Offset.Zero
+                }
+            }
+        }
+        .graphicsLayer(
+            scaleX = scale,
+            scaleY = scale,
+            translationX = offset.x,
+            translationY = offset.y
+        )
+}

--- a/app/src/main/java/org/example/memosm/ui/nav/AttachmentsScreen.kt
+++ b/app/src/main/java/org/example/memosm/ui/nav/AttachmentsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -41,6 +42,7 @@ import org.example.memosm.R
 import org.example.memosm.ui.component.ErrorView
 import org.example.memosm.ui.component.item.AttachmentCard
 import org.example.memosm.ui.component.item.AttachmentCompactMode
+import org.example.memosm.ui.component.item.media.FullScreenAttachmentViewer
 import org.example.memosm.ui.component.rememberStaggeredGridScrollContext
 import org.example.memosm.viewmodel.MemosViewModel
 
@@ -53,6 +55,9 @@ fun AttachmentsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val listState = rememberLazyStaggeredGridState()
+
+    var showFullScreenViewer by remember { mutableStateOf(false) }
+    var fullScreenInitialIndex by remember { mutableStateOf(0) }
 
     // Limits for zooming
     val minCellWidth = 100.dp
@@ -196,6 +201,10 @@ fun AttachmentsScreen(
                                 .fillMaxWidth()
                                 .aspectRatio(ratio)
                                 .animateItem(),
+                            onClick = {
+                                fullScreenInitialIndex = index
+                                showFullScreenViewer = true
+                            },
                             onRatioAvailable = { newRatio, isExact ->
                                 if (isExact) {
                                     viewModel.updateAttachmentAspectRatio(
@@ -235,5 +244,20 @@ fun AttachmentsScreen(
                 }
             }
         }
+    }
+
+    if (showFullScreenViewer) {
+        FullScreenAttachmentViewer(
+            attachments = uiState.attachmentList.list.items,
+            initialIndex = fullScreenInitialIndex,
+            token = uiState.session.token,
+            hostUrl = uiState.session.hostUrl,
+            onDismiss = { showFullScreenViewer = false },
+            onPageChanged = { index ->
+                if (index >= uiState.attachmentList.list.items.size - 5 && uiState.attachmentList.list.nextPageToken != null && !uiState.attachmentList.list.isLoading) {
+                    viewModel.loadMoreAttachments()
+                }
+            }
+        )
     }
 }


### PR DESCRIPTION
This PR introduces a unified full screen attachment viewer that allows users to swipe left and right to navigate through their attachments.

Key changes:
- **FullScreenAttachmentViewer**: A new component that uses a `HorizontalPager` to display a list of attachments in full screen, allowing users to swipe through them. It also supports a vertical swipe-to-dismiss gesture.
- **AttachmentCard**: Updated to handle a new `isFullScreen` flag, which simplifies its UI (hiding titles, footers, and menus) when viewed in full screen, and passes that state down to media renderers.
- **MemoImage & VideoPlayer**: Both updated with pinch-to-zoom gestures when `isFullScreen` is true.
- **AttachmentsScreen & MemoItem**: Hooked up to open the new viewer. In the `AttachmentsScreen`, swiping near the end of the attachment list automatically triggers fetching the next page of attachments.

---
*PR created automatically by Jules for task [8854220472692893442](https://jules.google.com/task/8854220472692893442) started by @yamada-sexta*